### PR TITLE
Use include/Lfunction instead of include/libLfunction

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,5 +18,7 @@ make
 make install INSTALL_DIR="$PREFIX"
 
 # Delete unnecessary files
-rm -f ${PREFIX}/include/libLfunction/*.crap
-rm -f ${PREFIX}/include/libLfunction/*.bak
+rm -f ${PREFIX}/include/Lfunction/*.crap
+rm -f ${PREFIX}/include/Lfunction/*.bak
+
+ln -s ${PREFIX}/include/Lfunction ${PREFIX}/include/libLfunction

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/using_namespace_std.patch
 
 build:
-  number: 1003
+  number: 1004
   skip: true  # [win]
 
 requirements:
@@ -43,6 +43,7 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/include/libLfunction/L.h
+    - test -f ${PREFIX}/include/Lfunction/L.h
     - test -f ${PREFIX}/lib/libLfunction.dylib     # [osx]
     - test -f ${PREFIX}/lib/libLfunction.so        # [linux]
 

--- a/recipe/patches/Makefile.patch
+++ b/recipe/patches/Makefile.patch
@@ -231,7 +231,7 @@ index 84e4e88..5d263a6 100644
 -	cp -rf ../include $(INSTALL_DIR)/include/Lfunction
 +	cp -f lcalc$(EXEEXT) $(INSTALL_DIR)/bin/.
 +	cp -f libLfunction$(LIBEXT) $(INSTALL_DIR)/lib/.
-+	cp -rf ../include $(INSTALL_DIR)/include/libLfunction
++	cp -rf ../include $(INSTALL_DIR)/include/Lfunction
  
  
  SRCS = Lcommandline.cc Lcommandline_elliptic.cc Lcommandline_globals.cc Lcommandline_misc.cc Lcommandline_numbertheory.cc Lcommandline_twist.cc Lcommandline_values_zeros.cc Lgamma.cc Lglobals.cc Lmisc.cc Lriemannsiegel.cc Lriemannsiegel_blfi.cc cmdline.c


### PR DESCRIPTION
Kept include/libLfunction as a symlink for backwards compat.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
